### PR TITLE
Add support for minitest-reporters

### DIFF
--- a/lib/minitest/parallel_fork.rb
+++ b/lib/minitest/parallel_fork.rb
@@ -45,6 +45,10 @@ module Minitest
   def self.__run(reporter, options)
     suites = Runnable.runnables.shuffle
     stat_reporter = reporter.reporters.detect{|rep| rep.is_a?(StatisticsReporter)}
+    if !stat_reporter && defined?(Minitest::Reporters)
+      delegate_reporter = reporter.reporters.detect{|rep| rep.is_a?(Minitest::Reporters::DelegateReporter)}
+      stat_reporter = delegate_reporter.send(:all_reporters).detect{|rep| rep.is_a?(StatisticsReporter)}
+    end
 
     n = (ENV['NCPU'] || 4).to_i
     reads = []

--- a/minitest-parallel_fork.gemspec
+++ b/minitest-parallel_fork.gemspec
@@ -21,4 +21,5 @@ such as when specs modify the constant namespace.
 END
 
   s.add_development_dependency "minitest", '>5'
+  s.add_development_dependency "minitest-reporters", '>1'
 end

--- a/spec/minitest_parallel_fork_example.rb
+++ b/spec/minitest_parallel_fork_example.rb
@@ -2,12 +2,18 @@ gem 'minitest'
 require 'minitest/autorun'
 require 'minitest/parallel_fork'
 
+if ENV['MPF_TEST_MINITEST_REPORTERS']
+  require "minitest/reporters"
+  # The minitest-reporters delegate code is activated as soon as it's required
+  #  Actually, it's activated as soon as minitest is loaded because of minitest's
+  #  plugin autoloading, but that's not our fault
+end
+
 a = nil
 Minitest.before_parallel_fork do
   a = 'a'
   print ":parent"
 end
-
 Minitest.after_parallel_fork do |i|
   print ":child#{i}#{a}"
 end

--- a/spec/minitest_parallel_fork_spec.rb
+++ b/spec/minitest_parallel_fork_spec.rb
@@ -4,7 +4,8 @@ require 'minitest/autorun'
 describe 'minitest/parallel_fork' do
   [[nil, ''],
    ['MPF_PARALLELIZE_ME', ' when parallelize_me! is used'],
-   ['MPF_TEST_ORDER_PARALLEL', ' when test_order parallel is used']
+   ['MPF_TEST_ORDER_PARALLEL', ' when test_order parallel is used'],
+   ['MPF_TEST_MINITEST_REPORTERS', ' when minitest-reporters is in use']
   ].each do |env_key, msg|
     it "should execute in parallel#{msg}" do
       t = Time.now


### PR DESCRIPTION
Just to warn you, due to how Minitest's plugins are handled, even having `minitest-reporters` on your gem path means it will be automatically loaded.