### PR TITLE
Support larger amounts of data in IO pipes

### DIFF
--- a/lib/minitest/parallel_fork.rb
+++ b/lib/minitest/parallel_fork.rb
@@ -62,7 +62,7 @@ module Minitest
     threads =
       reads.map do |read|
         Thread.new do
-          result = "".dup
+          result = String.new
 
           loop do
             begin


### PR DESCRIPTION
This fixes #4, for my use case at least.

- There's not a ton of rationale behind my picking 4k for the read byte size. `read_nonblock` needed an argument, it seems like a reasonable, middle-of-the-road value and it works on my linux distribution. There may be a better value for it.
- I wasn't sure of the purpose of the thread in the original implementation, but it did make me feel better about taking the approach of wrapping each IO loop in its own thread, I suppose. I originally tried iterating over all the pipes in the main thread, but that was kind of complicated - this is a simpler type of flow (using IO::WaitReadable) that it's easier to find examples of in the IO documentation.
- Frozen string literals aren't currently used in this gem, but since I think Ruby is trending towards making that the default behavior in the future, I opted to future-proof things by dup-ing the empty string.

Feedback welcome!