### PR TITLE
Add C-c and 2x C-c support

### DIFF
--- a/lib/minitest/parallel_fork.rb
+++ b/lib/minitest/parallel_fork.rb
@@ -95,9 +95,15 @@ class << Minitest
         write.write(Marshal.dump(parallel_fork_data_to_marshal))
         write.close
       end
+      run_after_parallel_fork_setup_hook(pid)
       write.close
       [pid, read]
     end
+  end
+
+  def run_after_parallel_fork_setup_hook(pid)
+    # See interrupt.rb
+    nil
   end
 
   def parallel_fork_child_data(data)

--- a/lib/minitest/parallel_fork/fail_fast.rb
+++ b/lib/minitest/parallel_fork/fail_fast.rb
@@ -1,68 +1,16 @@
+require_relative 'halt'
 require_relative '../parallel_fork'
 
 module Minitest::ParalleForkFailFast
-  def run_after_parallel_fork_hook(i)
-    super
-    Signal.trap(:USR1) do
-      @parallel_fork_stop = true
-    end
-  end
-
-  def parallel_fork_data_to_marshal
-    super << @parallel_fork_stop
-  end
-
-  def parallel_fork_data_from_marshal(data)
-    data = Marshal.load(data)
-    @parallel_fork_stop = true if data.pop
-    data
-  end
-
-  def parallel_fork_run_test_suites(suites, reporter, options)
-    suites.each do |suite|
-      parallel_fork_run_test_suite(suite, reporter, options)
-
-      # Fail fast if this child process had a failure,
-      # Or the USR1 signal was received indicating other child processes had a failure.
-      break if @parallel_fork_stop
-    end
-  end
+  include Minitest::ParallelForkHalt
 
   def parallel_fork_run_test_suite(suite, reporter, options)
     super
-
 
     if parallel_fork_stat_reporter.results.any?{|r| !r.failure.is_a?(Minitest::Skip)}
       # At least one failure or error, mark as failing fast
       @parallel_fork_stop = true
     end
-  end
-
-  def parallel_fork_child_data(data)
-    threads = {}
-    data.each{|pid, read| threads[pid] = Thread.new(read, &:read)}
-    results = []
-
-    while sleep(0.01) && !threads.empty?
-      threads.to_a.each do |pid, thread|
-        unless thread.alive?
-          threads.delete(pid)
-          results << parallel_fork_data_from_marshal(thread.value)
-
-          if @parallel_fork_stop
-            # If any child failed fast, signal other children to fail fast
-            threads.each_key do |pid|
-              Process.kill(:USR1, pid)
-            end
-
-            # Set a flag indicating that all child processes have been signaled
-            @parallel_fork_stop = :FINISHED
-          end
-        end
-      end
-    end
-
-    results
   end
 end
 

--- a/lib/minitest/parallel_fork/halt.rb
+++ b/lib/minitest/parallel_fork/halt.rb
@@ -1,0 +1,55 @@
+module Minitest::ParallelForkHalt
+  def run_after_parallel_fork_hook(i)
+    super
+    Signal.trap(:USR1) do
+      @parallel_fork_stop = true
+    end
+  end
+
+  def parallel_fork_data_to_marshal
+    super << @parallel_fork_stop
+  end
+
+  def parallel_fork_data_from_marshal(data)
+    data = Marshal.load(data)
+    @parallel_fork_stop = true if data.pop
+    data
+  end
+
+  def parallel_fork_run_test_suites(suites, reporter, options)
+    suites.each do |suite|
+      parallel_fork_run_test_suite(suite, reporter, options)
+
+      # Fail fast if this child process had a failure,
+      # Or the USR1 signal was received indicating other child processes had a failure.
+      break if @parallel_fork_stop
+    end
+  end
+
+  def parallel_fork_child_data(data)
+    threads = {}
+    data.each{|pid, read| threads[pid] = Thread.new(read, &:read)}
+    results = []
+
+    while sleep(0.01) && !threads.empty?
+      threads.to_a.each do |pid, thread|
+        unless thread.alive?
+          threads.delete(pid)
+          results << parallel_fork_data_from_marshal(thread.value)
+
+          if @parallel_fork_stop
+            # If any child failed fast, signal other children to fail fast
+            threads.each_key do |pid|
+              Process.kill(:USR1, pid)
+            end
+
+            # Set a flag indicating that all child processes have been signaled
+            @parallel_fork_stop = :FINISHED
+          end
+        end
+      end
+    end
+
+    results
+  end
+end

--- a/lib/minitest/parallel_fork/halt.rb
+++ b/lib/minitest/parallel_fork/halt.rb
@@ -20,8 +20,8 @@ module Minitest::ParallelForkHalt
     suites.each do |suite|
       parallel_fork_run_test_suite(suite, reporter, options)
 
-      # Fail fast if this child process had a failure,
-      # Or the USR1 signal was received indicating other child processes had a failure.
+      # Halt if this child process requested an exit,
+      # Or other child processes requested an exit.
       break if @parallel_fork_stop
     end
   end
@@ -38,7 +38,7 @@ module Minitest::ParallelForkHalt
           results << parallel_fork_data_from_marshal(thread.value)
 
           if @parallel_fork_stop
-            # If any child failed fast, signal other children to fail fast
+            # If halt is requested, signal other children to halt
             threads.each_key do |pid|
               Process.kill(:USR1, pid)
             end

--- a/lib/minitest/parallel_fork/interrupt.rb
+++ b/lib/minitest/parallel_fork/interrupt.rb
@@ -1,0 +1,44 @@
+require_relative 'halt'
+require_relative '../parallel_fork'
+
+module Minitest
+  @parallel_fork_child_pids ||= []
+end
+
+module Minitest::ParallelForkInterrupt
+  include Minitest::ParallelForkHalt
+
+  def run_before_parallel_fork_hook
+    Signal.trap(:INT) do
+      Signal.trap(:INT) do
+        parallel_fork_kill_all :KILL
+      end
+      puts "\nInterrupted."
+      puts 'Exiting ...'
+      puts 'Interrupt again to exit now.'
+      at_exit { exit 130 }
+      parallel_fork_kill_all :USR1
+    end
+  end
+
+  def run_after_parallel_fork_hook(i)
+    super
+    Signal.trap(:INT, 'IGNORE')
+  end
+
+  def run_after_parallel_fork_setup_hook(pid)
+    super
+    @parallel_fork_child_pids << pid
+  end
+
+  def parallel_fork_kill_all(signal)
+    @parallel_fork_child_pids.each do |pid|
+      Process.kill(signal, pid)
+    rescue Errno::ESRCH
+      # Process already terminated
+    end
+  end
+
+end
+
+Minitest.singleton_class.prepend(Minitest::ParallelForkInterrupt)

--- a/spec/minitest_parallel_fork_interrupt_example.rb
+++ b/spec/minitest_parallel_fork_interrupt_example.rb
@@ -1,0 +1,10 @@
+require 'minitest/global_expectations/autorun'
+require 'minitest/parallel_fork/interrupt'
+
+4.times do |i|
+  describe "test suite with interrupt - #{i}" do
+    it "should wait" do
+      sleep(1) while true
+    end
+  end
+end


### PR DESCRIPTION
Hello Jeremy,

I am submitting something I'm using internally for a while now and it's really useful to my use case.

Often, hitting C-c vomits pages and pages of stack traces. 

What I want is to allow the test suite to stop as soon as possible, as if I asked for a fail fast and something failed (but not really), so I could get the reports at the end … and If I really want to quit, I just hit C-c a second time, and _I should **NOT** get pages of stack traces_.

I didn't include any tests because I don't know if you'd want to include this feature in the first place, and to be quite frank, I am not so sure how I would go about it.

Anyway, I tried to copy your work on fail fast, and make it opt-in.